### PR TITLE
Allow version to be chosen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ NSIS CHANGELOG
 
 This file is used to list changes made in each version of the NSIS cookbook.
 
+v0.2.0 (2016-01-07)
+-------------------
+
+* Allow choosing of a version using ```node['nsis']['version']```
 
 v0.1.0 (2015-10-02)
 -------------------

--- a/README.md
+++ b/README.md
@@ -1,31 +1,46 @@
-NSIS Cookbook
-==============
-[NSIS](http://nsis.sourceforge.net/) A scriptable win32 installer/uninstaller system.
+# NSIS Cookbook
 
-Requirements
-============
+[NSIS](http://nsis.sourceforge.net/) - A scriptable win32 installer/uninstaller system.
 
-CentOS/RedHat (may perhaps work with other RPM distros, but is not tested)
 
-Cookbooks
----------
+# Requirements
+
+## Platforms
+
+* CentOS/RedHat (may perhaps work with other RPM distros, but is not tested)
+
+## Dependent Cookbooks
 
 * yum
 
-Usage
-=====
 
-Include the default recipe on a node's runlist to ensure that NSIS is installed.
+# Usage
 
-## Contributing
+## Recipes
 
-We encourage you to contribute to Go. For information on contributing to this project, please see our [contributor's guide](http://www.go.cd/contribute).
-A lot of useful information like links to user documentation, design documentation, mailing lists etc. can be found in the [resources](http://www.go.cd/community/resources.html) section.
+* default - Include the default recipe on a node's runlist to ensure that NSIS is installed.
+
+## Attributes
+
+The following attributes can be used to change behavior:
+
+* ```node['nsis']['version']```
+    - Setting it to "latest" (default) always upgrades nsis to the latest available revision in the repository.
+    - It can be set to any available version (such as: "2.50-15.el6") to pin it to that revision.
+
+
+# Contributing
+
+We encourage you to contribute to GoCD. For information on contributing to this
+project, please see our [contributor's guide](http://www.go.cd/contribute).  A
+lot of useful information like links to user documentation, design
+documentation, mailing lists etc. can be found in the
+[resources](http://www.go.cd/community/resources.html) section.
 
 ## License
 
 ```plain
-Copyright 2015 ThoughtWorks, Inc.
+Copyright 2016 ThoughtWorks, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/attributes/main.rb
+++ b/attributes/main.rb
@@ -1,0 +1,1 @@
+default['nsis']['version'] = 'latest'

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,10 +1,10 @@
 name             'nsis'
 maintainer       'Ketan Padegaonkar'
 maintainer_email 'ketanpadegaonkar@gmail.com'
-license          'MIT'
+license          'Apache v2.0'
 description      'Installs/Configures NSIS'
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.1.0'
+version          '0.2.0'
 
 depends 'yum'
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -5,4 +5,10 @@ yum_repository 'nsis' do
   action      :create
 end
 
-package 'mingw32-nsis'
+package 'mingw32-nsis' do
+  if node['nsis']['version'] == 'latest'
+    action :upgrade
+  else if node['nsis']['version']
+    version node['nsis']['version']
+  end
+end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -1,6 +1,6 @@
 yum_repository 'nsis' do
   description "NSIS RPM Repository"
-  baseurl     "http://www.go.cd/nsis-rpm/"
+  baseurl     "https://www.go.cd/nsis-rpm/"
   gpgcheck    false
   action      :create
 end


### PR DESCRIPTION
- Use "latest" to always upgrade to latest.
- Otherwise, use a full version like: "2.46-15.el6".
